### PR TITLE
Update and test the logging level and its mechanisms

### DIFF
--- a/cblogger.go
+++ b/cblogger.go
@@ -111,8 +111,7 @@ func SetLevel(strLevel string) {
 
 	level, err := logrus.ParseLevel(strLevel)
 	if err != nil {
-		thisLogger.logrus.Errorf("Failed to set log level: %v", strLevel)
-		thisLogger.logrus.Info("Set to Debug, the default logging level.")
+		thisLogger.logrus.Warnf("Not available logging level: %v. Default logging level will be used: debug", strLevel)
 		level = logrus.DebugLevel
 	}
 	thisLogger.logrus.SetLevel(level)

--- a/cblogger.go
+++ b/cblogger.go
@@ -10,9 +10,7 @@
 package cblog
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	cblogformatter "github.com/cloud-barista/cb-log/formatter"
@@ -110,26 +108,14 @@ func setRotateFileHook(loggerName string, logConfig *CBLOGCONFIG) {
 }
 
 func SetLevel(strLevel string) {
-	err := checkLevel(strLevel)
-	if err != nil {
-		logrus.Errorf("Failed to set log level: %v", err)
-	}
-	level, _ := logrus.ParseLevel(strLevel)
-	thisLogger.logrus.SetLevel(level)
-}
 
-func checkLevel(lvl string) error {
-	switch strings.ToLower(lvl) {
-	case "error":
-		return nil
-	case "warn", "warning":
-		return nil
-	case "info":
-		return nil
-	case "debug":
-		return nil
+	level, err := logrus.ParseLevel(strLevel)
+	if err != nil {
+		thisLogger.logrus.Errorf("Failed to set log level: %v", strLevel)
+		thisLogger.logrus.Info("Set to Debug, the default logging level.")
+		level = logrus.DebugLevel
 	}
-	return fmt.Errorf("not a valid cblog Level: %q", lvl)
+	thisLogger.logrus.SetLevel(level)
 }
 
 func GetLevel() string {

--- a/conf/log_conf.yaml
+++ b/conf/log_conf.yaml
@@ -4,7 +4,8 @@ cblog:
   ## true | false
   loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
 
-  ## debug | info | warn | error
+  ## trace | debug | info | warn/warning | error | fatal | panic
+  ## Default logging level: debug
   loglevel: debug # If loopcheck is true, You can set this online.
 
   ## true | false

--- a/test/test-all-logging-level.go
+++ b/test/test-all-logging-level.go
@@ -43,12 +43,12 @@ func main() {
 	//cblogger.Panicf("Panicf() test: Hello CBLogger from %s", "Cloud-Barista")
 
 	fmt.Printf("\n####LogLevel: %s\n", cblog.GetLevel())
-	// WithField 테스트
-	cblogger.WithField("TestField", "test").Debug("WithField 테스트")
-	// WithFields 테스트
-	cblogger.WithFields(logrus.Fields{"Field1": "value1", "Field2": "value2", "Field3": "value3"}).Debug("WithFields 테스트")
-	// WithError 테스트
-	cblogger.WithError(errors.New("테스트 오류")).Debug("WithError 테스트")
+	// WithField test
+	cblogger.WithField("TestField", "test").Debug("WithField test")
+	// WithFields test
+	cblogger.WithFields(logrus.Fields{"Field1": "value1", "Field2": "value2", "Field3": "value3"}).Debug("WithFields test")
+	// WithError test
+	cblogger.WithError(errors.New("Test-error")).Debug("WithError test")
 
 	//	fmt.Printf("===> %#v\n", cblogger.Hooks[0][0])
 }

--- a/test/test-all-logging-level.go
+++ b/test/test-all-logging-level.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	cblog "github.com/cloud-barista/cb-log"
+	"github.com/sirupsen/logrus"
+)
+
+var cblogger *logrus.Logger
+
+func init() {
+	// cblog is a global variable.
+	filePath := filepath.Join("..", "conf", "log_conf.yaml")
+	cblogger = cblog.GetLoggerWithConfigPath("TEST", filePath)
+}
+
+func main() {
+
+	fmt.Printf("\n####LogLevel: %s\n", cblog.GetLevel())
+	cblogger.Trace("Trace() test: Hello CBLogger")
+	cblogger.Tracef("Tracef() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	cblogger.Debug("Debug() test: Hello CBLogger")
+	cblogger.Debugf("Debugf() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	cblogger.Info("Info() test: Hello CBLogger")
+	cblogger.Infof("Infof() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	cblogger.Warn("Warn() test: Hello CBLogger")
+	cblogger.Warnf("Warnf() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	cblogger.Error("Error() test: Hello CBLogger")
+	cblogger.Errorf("Errorf() test: Hello CBLogger - %s", getDummyErrorMsg())
+
+	// Fatal and panic should be tested one by one because the two include the exit process.
+	cblogger.Fatal("Fatal() test: Hello CBLogger")
+	//cblogger.Fatalf("Fatalf() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	//cblogger.Panic("Panic() test: Hello CBLogger")
+	//cblogger.Panicf("Panicf() test: Hello CBLogger from %s", "Cloud-Barista")
+
+	fmt.Printf("\n####LogLevel: %s\n", cblog.GetLevel())
+	// WithField 테스트
+	cblogger.WithField("TestField", "test").Debug("WithField 테스트")
+	// WithFields 테스트
+	cblogger.WithFields(logrus.Fields{"Field1": "value1", "Field2": "value2", "Field3": "value3"}).Debug("WithFields 테스트")
+	// WithError 테스트
+	cblogger.WithError(errors.New("테스트 오류")).Debug("WithError 테스트")
+
+	//	fmt.Printf("===> %#v\n", cblogger.Hooks[0][0])
+}
+
+func getDummyErrorMsg() error {
+	return fmt.Errorf("internal error message")
+}


### PR DESCRIPTION
### [기존 Logging level 업데이트]
- 기존 Logging level: debug, info, warn, error
- 업데이트한 Logging level: trace, debug, info, warn, error, fatal, panic

### [Logging level 업데이트를 위한 변경 사항]
- Delete the existing checkLevel() to use trace, fatal, panic
- Check logrus.ParseLevel() to cope with wrong logging level
- Update logging level guide in log_conf.yaml
- Test all logging level by test-all-logging-level.go

### [테스트]
#### 테스트 개요
아래와 같이 Trace가 가장 많은 로깅 정보를 보여주기 때문에 테스트는 trace부터 시작하였습니다. ([참고](https://github.com/cb-contributhon/cb-coffeehouse/wiki/The-logging-level-to-understand-through-examples))
- Trace > Debug > Info > Warn > Error > Fatal > Panic
- 예외: ttt로 잘못 입력한 경우

#### 테스트 결과
- Logging level: trace
```
####LogLevel: trace
[TEST].[TRACE]: 2021-01-22 15:46:51 test-all-logging-level.go:23, main.main() - Trace() test: Hello CBLogger 
[TEST].[TRACE]: 2021-01-22 15:46:51 test-all-logging-level.go:24, main.main() - Tracef() test: Hello CBLogger from Cloud-Barista 
[TEST].[DEBUG]: 2021-01-22 15:46:51 test-all-logging-level.go:26, main.main() - Debug() test: Hello CBLogger 
[TEST].[DEBUG]: 2021-01-22 15:46:51 test-all-logging-level.go:27, main.main() - Debugf() test: Hello CBLogger from Cloud-Barista 
[TEST].[INFO]: 2021-01-22 15:46:51 test-all-logging-level.go:29, main.main() - Info() test: Hello CBLogger 
[TEST].[INFO]: 2021-01-22 15:46:51 test-all-logging-level.go:30, main.main() - Infof() test: Hello CBLogger from Cloud-Barista 
[TEST].[WARNING]: 2021-01-22 15:46:51 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 15:46:51 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 15:46:51 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:46:51 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 15:46:51 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

- Logging level: debug
```
####LogLevel: debug
[TEST].[DEBUG]: 2021-01-22 15:48:21 test-all-logging-level.go:26, main.main() - Debug() test: Hello CBLogger 
[TEST].[DEBUG]: 2021-01-22 15:48:21 test-all-logging-level.go:27, main.main() - Debugf() test: Hello CBLogger from Cloud-Barista 
[TEST].[INFO]: 2021-01-22 15:48:21 test-all-logging-level.go:29, main.main() - Info() test: Hello CBLogger 
[TEST].[INFO]: 2021-01-22 15:48:21 test-all-logging-level.go:30, main.main() - Infof() test: Hello CBLogger from Cloud-Barista 
[TEST].[WARNING]: 2021-01-22 15:48:21 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 15:48:21 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 15:48:21 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:48:21 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 15:48:21 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

- Logging level: info
```
####LogLevel: info
[TEST].[INFO]: 2021-01-22 15:49:09 test-all-logging-level.go:29, main.main() - Info() test: Hello CBLogger 
[TEST].[INFO]: 2021-01-22 15:49:09 test-all-logging-level.go:30, main.main() - Infof() test: Hello CBLogger from Cloud-Barista 
[TEST].[WARNING]: 2021-01-22 15:49:09 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 15:49:09 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 15:49:09 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:49:09 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 15:49:09 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

- Logging level: warn
```
####LogLevel: warning
[TEST].[WARNING]: 2021-01-22 15:49:42 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 15:49:42 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 15:49:42 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:49:42 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 15:49:42 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

- Logging level: error
```
####LogLevel: error
[TEST].[ERROR]: 2021-01-22 15:50:10 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:50:10 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 15:50:10 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

☑️ <ins>**Fatal과 Panic은 os.Exit() 구분으로 강제 종료 되기 때문에 각각 테스트 하였습니다.(Panic 테스트 시 Fatal 주석처리)**</ins>

- Logging level: fatal
```
####LogLevel: fatal
[TEST].[FATAL]: 2021-01-22 15:53:18 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

Process finished with exit code 1
```

- Logging level: panic
```
####LogLevel: panic
[TEST].[PANIC]: 2021-01-22 15:52:19 test-all-logging-level.go:42, main.main() - Panic() test: Hello CBLogger 
panic: (*logrus.Entry) 0xc0001018f0

goroutine 1 [running]:
github.com/sirupsen/logrus.Entry.log(0xc000101650, 0xc0000669f0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	C:/gopath/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:259 +0x34d
github.com/sirupsen/logrus.(*Entry).Log(0xc000101880, 0xc000000000, 0xc000077de8, 0x1, 0x1)
	C:/gopath/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:287 +0xf2
github.com/sirupsen/logrus.(*Logger).Log(0xc000101650, 0x0, 0xc000077de8, 0x1, 0x1)
	C:/gopath/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:193 +0x85
github.com/sirupsen/logrus.(*Logger).Panic(...)
	C:/gopath/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:234
main.main()
	C:/Dev/Cloud-Barista/cb-log/test/test-all-logging-level.go:42 +0x568

Process finished with exit code 2
```

- Logging level: trace (cblogger.WithField() 테스트)
```
####LogLevel: trace
[TEST].[TRACE]: 2021-01-22 15:54:25 test-all-logging-level.go:23, main.main() - Trace() test: Hello CBLogger 
[TEST].[TRACE]: 2021-01-22 15:54:25 test-all-logging-level.go:24, main.main() - Tracef() test: Hello CBLogger from Cloud-Barista 
[TEST].[DEBUG]: 2021-01-22 15:54:25 test-all-logging-level.go:26, main.main() - Debug() test: Hello CBLogger 
[TEST].[DEBUG]: 2021-01-22 15:54:25 test-all-logging-level.go:27, main.main() - Debugf() test: Hello CBLogger from Cloud-Barista 
[TEST].[INFO]: 2021-01-22 15:54:25 test-all-logging-level.go:29, main.main() - Info() test: Hello CBLogger 
[TEST].[INFO]: 2021-01-22 15:54:25 test-all-logging-level.go:30, main.main() - Infof() test: Hello CBLogger from Cloud-Barista 
[TEST].[WARNING]: 2021-01-22 15:54:25 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 15:54:25 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 15:54:25 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 15:54:25 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[DEBUG]: 2021-01-22 15:54:25 test-all-logging-level.go:47, main.main() - WithField 테스트 	[TestField=test]
[TEST].[DEBUG]: 2021-01-22 15:54:25 test-all-logging-level.go:49, main.main() - WithFields 테스트 	[Field1=value1,Field2=value2,Field3=value3]
[TEST].[DEBUG]: 2021-01-22 15:54:25 test-all-logging-level.go:51, main.main() - WithError 테스트 	[error=테스트 오류]

Process finished with exit code 0
```

- Logging level: ttt (❗ ❗ ❗ 잘못 입력 시❗ ❗ ❗ )
```
[TEST].[ERROR]: 2021-01-22 16:01:23 cblogger.go:114, github.com/cloud-barista/cb-log.SetLevel() - Failed to set log level: ttt 
[TEST].[INFO]: 2021-01-22 16:01:23 cblogger.go:115, github.com/cloud-barista/cb-log.SetLevel() - Set to Debug, the default logging level. 
[TEST].[DEBUG]: 2021-01-22 16:01:23 test-all-logging-level.go:26, main.main() - Debug() test: Hello CBLogger 
[TEST].[DEBUG]: 2021-01-22 16:01:23 test-all-logging-level.go:27, main.main() - Debugf() test: Hello CBLogger from Cloud-Barista 
[TEST].[INFO]: 2021-01-22 16:01:23 test-all-logging-level.go:29, main.main() - Info() test: Hello CBLogger 
[TEST].[INFO]: 2021-01-22 16:01:23 test-all-logging-level.go:30, main.main() - Infof() test: Hello CBLogger from Cloud-Barista 
[TEST].[WARNING]: 2021-01-22 16:01:23 test-all-logging-level.go:32, main.main() - Warn() test: Hello CBLogger 
[TEST].[WARNING]: 2021-01-22 16:01:23 test-all-logging-level.go:33, main.main() - Warnf() test: Hello CBLogger from Cloud-Barista 
[TEST].[ERROR]: 2021-01-22 16:01:23 test-all-logging-level.go:35, main.main() - Error() test: Hello CBLogger 
[TEST].[ERROR]: 2021-01-22 16:01:23 test-all-logging-level.go:36, main.main() - Errorf() test: Hello CBLogger - internal error message 
[TEST].[FATAL]: 2021-01-22 16:01:23 test-all-logging-level.go:39, main.main() - Fatal() test: Hello CBLogger 

####LogLevel: debug

Process finished with exit code 1
```