### PR TITLE
Overwrite logger name

### DIFF
--- a/cblogger.go
+++ b/cblogger.go
@@ -46,6 +46,11 @@ func GetLoggerWithConfigPath(loggerName string, configFilePath string) *logrus.L
 func getLoggerHandler(loggerName string, configFilePath string) *logrus.Logger {
 
 	if thisLogger != nil {
+		if loggerName != "" {
+			thisLogger.loggerName = loggerName
+			thisLogger.logrus.SetFormatter(getFormatter(loggerName))
+			setup(loggerName, configFilePath)
+		}
 		return thisLogger.logrus
 	}
 	thisLogger = new(CBLogger)
@@ -123,13 +128,11 @@ func GetLevel() string {
 
 func getFormatter(loggerName string) *cblogformatter.Formatter {
 
-	if thisFormatter != nil {
-		return thisFormatter
-	}
 	// 출력 포맷 조정 (keyvalues) 추가 (Formatter.go에서 해당 위치에 실제 데이터로 변경)
 	thisFormatter = &cblogformatter.Formatter{
 		TimestampFormat: "2006-01-02 15:04:05",
 		LogFormat:       "[" + loggerName + "]." + "[%lvl%]: %time% %func% - %msg% \t[%keyvalues%]\n",
 	}
+
 	return thisFormatter
 }


### PR DESCRIPTION
이번 PR은 Logger name을 변경하기 위한 PR 입니다 ^^
(CB-Larva에서 분산 로깅을 적용한 후 인지한 사항 입니다.)

기존 cb-log는, logger가 생성되어 있는 경우 해당 logger를 return하여 Logger name을 변경할 수 없었습니다.

이를, Logger name이 있는 경우 변경(덮어쓰기)하고, return 하는 것으로 수정하고자 합니다.

CB-Larva에서 빌드 및 로깅 테스트를 수행하였습니다.

추가 검토해야할 사항이 있으면 말씀해주시기 바랍니다.