### PR TITLE
Fix duplicate logging to file

### DIFF
--- a/cblogger.go
+++ b/cblogger.go
@@ -49,10 +49,10 @@ func getLoggerHandler(loggerName string, configFilePath string) *logrus.Logger {
 		if loggerName != "" {
 			thisLogger.loggerName = loggerName
 			thisLogger.logrus.SetFormatter(getFormatter(loggerName))
-			setup(loggerName, configFilePath)
 		}
 		return thisLogger.logrus
 	}
+
 	thisLogger = new(CBLogger)
 	thisLogger.loggerName = loggerName
 	thisLogger.logrus = &logrus.Logger{
@@ -127,6 +127,11 @@ func GetLevel() string {
 }
 
 func getFormatter(loggerName string) *cblogformatter.Formatter {
+
+	if thisFormatter != nil {
+		thisFormatter.LogFormat = "[" + loggerName + "]." + "[%lvl%]: %time% %func% - %msg% \t[%keyvalues%]\n"
+		return thisFormatter
+	}
 
 	// 출력 포맷 조정 (keyvalues) 추가 (Formatter.go에서 해당 위치에 실제 데이터로 변경)
 	thisFormatter = &cblogformatter.Formatter{


### PR DESCRIPTION
Bug fix 입니다.

로그 메시지를 파일에 여러번 기록하는 이슈를 수정하였습니다.

원인은, setup을 통해 Logger name을 수정한 경우 RotateFileHook을 추가하게 되어 같은 로그 메시지를 여러번 파일에 기록하는 문제였습니다.

setup() 하지 않고, formatter.LogFormat을 수정하는 것으로 변경 하였습니다.