### PR TITLE
fix: handle atomic file saves in config watcher

### DIFF
--- a/cblogger.go
+++ b/cblogger.go
@@ -10,189 +10,217 @@
 package cblog
 
 import (
-	"context"
-	"os"
-	"path/filepath"
+"context"
+"os"
+"path/filepath"
+"time"
 
-	cblogformatter "github.com/cloud-barista/cb-log/formatter"
-	"github.com/fsnotify/fsnotify"
-	"github.com/sirupsen/logrus"
-	"github.com/snowzach/rotatefilehook"
+cblogformatter "github.com/cloud-barista/cb-log/formatter"
+"github.com/fsnotify/fsnotify"
+"github.com/sirupsen/logrus"
+"github.com/snowzach/rotatefilehook"
 )
 
 type CBLogger struct {
-	loggerName string
-	logrus     *logrus.Logger
+loggerName string
+logrus     *logrus.Logger
 }
 
 // global var.
 var (
-	thisLogger    *CBLogger
-	thisFormatter *cblogformatter.Formatter
-	cblogConfig   CBLOGCONFIG
-	watcherCancel context.CancelFunc // stops the background watcher goroutine
+thisLogger    *CBLogger
+thisFormatter *cblogformatter.Formatter
+cblogConfig   CBLOGCONFIG
+watcherCancel context.CancelFunc // stops the background watcher goroutine
 )
 
 // Get the logger with name you set. The name will be used as below (name: CB-SPIDER)
 // [CB-SPIDER].[INFO]: 2020-12-24 16:54:46 sample-with-config-path.go:27, main.main() - start.........
 // Read configuration file (log_conf.yaml) by the path set on environment variable (e.g., $CBLOG_ROOT)
 func GetLogger(loggerName string) *logrus.Logger {
-	return getLoggerHandler(loggerName, "")
+return getLoggerHandler(loggerName, "")
 }
 
 // Read configuration file (log_conf.yaml) from the path you set
 func GetLoggerWithConfigPath(loggerName string, configFilePath string) *logrus.Logger {
-	return getLoggerHandler(loggerName, configFilePath)
+return getLoggerHandler(loggerName, configFilePath)
 }
 
 // The handler for GetLogger() and GetLoggerWithConfigPath()
 func getLoggerHandler(loggerName string, configFilePath string) *logrus.Logger {
 
-	if thisLogger != nil {
-		return thisLogger.logrus
-	}
-	thisLogger = new(CBLogger)
-	thisLogger.loggerName = loggerName
-	thisLogger.logrus = &logrus.Logger{
-		Level:     logrus.DebugLevel,
-		Out:       os.Stderr,
-		Hooks:     make(logrus.LevelHooks),
-		Formatter: getFormatter(loggerName),
-	}
+if thisLogger != nil {
+return thisLogger.logrus
+}
+thisLogger = new(CBLogger)
+thisLogger.loggerName = loggerName
+thisLogger.logrus = &logrus.Logger{
+Level:     logrus.DebugLevel,
+Out:       os.Stderr,
+Hooks:     make(logrus.LevelHooks),
+Formatter: getFormatter(loggerName),
+}
 
-	// set config.
-	setup(loggerName, configFilePath)
-	return thisLogger.logrus
+// set config.
+setup(loggerName, configFilePath)
+return thisLogger.logrus
 }
 
 func setup(loggerName string, configFilePath string) {
-	cblogConfig = GetConfigInfos(configFilePath)
-	thisLogger.logrus.SetReportCaller(true)
+cblogConfig = GetConfigInfos(configFilePath)
+thisLogger.logrus.SetReportCaller(true)
 
-	SetLevel(cblogConfig.CBLOG.LOGLEVEL)
-	ctx, cancel := context.WithCancel(context.Background())
-	watcherCancel = cancel
-	go levelSetupWatcher(ctx, loggerName, configFilePath)
+SetLevel(cblogConfig.CBLOG.LOGLEVEL)
+ctx, cancel := context.WithCancel(context.Background())
+watcherCancel = cancel
+go levelSetupWatcher(ctx, loggerName, configFilePath)
 
-	if cblogConfig.CBLOG.LOGFILE {
-		setRotateFileHook(loggerName, &cblogConfig)
-	}
+if cblogConfig.CBLOG.LOGFILE {
+setRotateFileHook(loggerName, &cblogConfig)
+}
 
-	if !cblogConfig.CBLOG.CONSOLE {
-		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-		if err != nil {
-			logrus.Fatalf("Failed to open os.DevNull: %v", err)
-		}
-		thisLogger.logrus.SetOutput(devNull)
-	} else {
-		thisLogger.logrus.SetOutput(os.Stderr)
-	}
+if !cblogConfig.CBLOG.CONSOLE {
+devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+if err != nil {
+logrus.Fatalf("Failed to open os.DevNull: %v", err)
+}
+thisLogger.logrus.SetOutput(devNull)
+} else {
+thisLogger.logrus.SetOutput(os.Stderr)
+}
 }
 
 // levelSetupWatcher watches the config file for changes using fsnotify
 // and updates the log level whenever the file is modified.
 // It stops when ctx is cancelled.
+//
+// To handle atomic saves (used by vim, emacs, sed -i, etc.) the watcher
+// monitors the parent *directory* of the config file. Atomic saves
+// remove/rename the original file and replace it with a new one, which
+// would break a direct file watch. Watching the directory ensures we
+// always receive the subsequent Create event when the new file appears.
 // ref) https://github.com/fsnotify/fsnotify/blob/master/example_test.go
 func levelSetupWatcher(ctx context.Context, loggerName string, configFilePath string) {
-	// Resolve the config file path the same way GetConfigInfos does.
-	watchPath := configFilePath
-	if watchPath == "" {
-		cblogRootPath := os.Getenv("CBLOG_ROOT")
-		if cblogRootPath != "" {
-			watchPath = filepath.Join(cblogRootPath, "conf", "log_conf.yaml")
-		}
-	}
+// Resolve the config file path the same way GetConfigInfos does.
+watchPath := configFilePath
+if watchPath == "" {
+cblogRootPath := os.Getenv("CBLOG_ROOT")
+if cblogRootPath != "" {
+watchPath = filepath.Join(cblogRootPath, "conf", "log_conf.yaml")
+}
+}
 
-	if watchPath == "" {
-		logrus.Warn("[cb-log] No config file path could be determined; file watcher will not start.")
-		return
-	}
+if watchPath == "" {
+logrus.Warn("[cb-log] No config file path could be determined; file watcher will not start.")
+return
+}
 
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		logrus.Errorf("[cb-log] Failed to create file watcher: %v", err)
-		return
-	}
-	defer watcher.Close()
+// Watch the parent directory instead of the file itself so that
+// atomic-save operations (remove + create) are handled correctly.
+watchDir := filepath.Dir(watchPath)
+watchBase := filepath.Base(watchPath)
 
-	if err := watcher.Add(watchPath); err != nil {
-		logrus.Errorf("[cb-log] Failed to watch config file %s: %v", watchPath, err)
-		return
-	}
+watcher, err := fsnotify.NewWatcher()
+if err != nil {
+logrus.Errorf("[cb-log] Failed to create file watcher: %v", err)
+return
+}
+defer watcher.Close()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return
-			}
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-				reloadConfig(configFilePath)
-			}
-			// Re-add the watch when the file is renamed/removed (e.g. atomic saves by vim/emacs).
-			if event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove) {
-				if err := watcher.Add(watchPath); err != nil {
-					logrus.Errorf("[cb-log] Failed to re-watch config file %s: %v", watchPath, err)
-				}
-				reloadConfig(configFilePath)
-			}
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return
-			}
-			logrus.Errorf("[cb-log] File watcher error: %v", err)
-		}
-	}
+if err := watcher.Add(watchDir); err != nil {
+logrus.Errorf("[cb-log] Failed to watch config directory %s: %v", watchDir, err)
+return
+}
+
+// debounce timer to coalesce rapid events from atomic saves.
+var debounceTimer *time.Timer
+
+for {
+select {
+case <-ctx.Done():
+return
+case event, ok := <-watcher.Events:
+if !ok {
+return
+}
+// Only react to events on our config file.
+if filepath.Base(event.Name) != watchBase {
+continue
+}
+if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+// Debounce: wait briefly for any follow-up events to settle.
+if debounceTimer != nil {
+debounceTimer.Stop()
+}
+debounceTimer = time.AfterFunc(200*time.Millisecond, func() {
+reloadConfig(configFilePath)
+})
+}
+// Rename/Remove events are expected during atomic saves;
+// the directory watch survives them, and the subsequent
+// Create event (handled above) will trigger the reload.
+case err, ok := <-watcher.Errors:
+if !ok {
+return
+}
+logrus.Errorf("[cb-log] File watcher error: %v", err)
+}
+}
 }
 
 // reloadConfig re-reads the config file and applies the new log level.
+// Errors are logged and silently ignored so that the process is not
+// terminated by a transient file-system condition (e.g. mid-atomic-save).
 func reloadConfig(configFilePath string) {
-	cblogConfig = GetConfigInfos(configFilePath)
-	SetLevel(cblogConfig.CBLOG.LOGLEVEL)
+newConfig, err := GetConfigInfosSafe(configFilePath)
+if err != nil {
+logrus.Warnf("[cb-log] Failed to reload config (keeping current settings): %v", err)
+return
+}
+cblogConfig = newConfig
+SetLevel(cblogConfig.CBLOG.LOGLEVEL)
 }
 
 func setRotateFileHook(loggerName string, logConfig *CBLOGCONFIG) {
-	level, _ := logrus.ParseLevel(logConfig.CBLOG.LOGLEVEL)
+level, _ := logrus.ParseLevel(logConfig.CBLOG.LOGLEVEL)
 
-	rotateFileHook, err := rotatefilehook.NewRotateFileHook(rotatefilehook.RotateFileConfig{
-		Filename:   logConfig.LOGFILEINFO.FILENAME,
-		MaxSize:    logConfig.LOGFILEINFO.MAXSIZE, // megabytes
-		MaxBackups: logConfig.LOGFILEINFO.MAXBACKUPS,
-		MaxAge:     logConfig.LOGFILEINFO.MAXAGE, //days
-		Level:      level,
-		Formatter:  getFormatter(loggerName),
-	})
+rotateFileHook, err := rotatefilehook.NewRotateFileHook(rotatefilehook.RotateFileConfig{
+Filename:   logConfig.LOGFILEINFO.FILENAME,
+MaxSize:    logConfig.LOGFILEINFO.MAXSIZE, // megabytes
+MaxBackups: logConfig.LOGFILEINFO.MAXBACKUPS,
+MaxAge:     logConfig.LOGFILEINFO.MAXAGE, //days
+Level:      level,
+Formatter:  getFormatter(loggerName),
+})
 
-	if err != nil {
-		logrus.Fatalf("Failed to initialize file rotate hook: %v", err)
-	}
-	thisLogger.logrus.AddHook(rotateFileHook)
+if err != nil {
+logrus.Fatalf("Failed to initialize file rotate hook: %v", err)
+}
+thisLogger.logrus.AddHook(rotateFileHook)
 }
 
 func SetLevel(strLevel string) {
 
-	level, err := logrus.ParseLevel(strLevel)
-	if err != nil {
-		thisLogger.logrus.Warnf("Not available logging level: %v. Default logging level will be used: debug", strLevel)
-		level = logrus.DebugLevel
-	}
-	thisLogger.logrus.SetLevel(level)
+level, err := logrus.ParseLevel(strLevel)
+if err != nil {
+thisLogger.logrus.Warnf("Not available logging level: %v. Default logging level will be used: debug", strLevel)
+level = logrus.DebugLevel
+}
+thisLogger.logrus.SetLevel(level)
 }
 
 func GetLevel() string {
-	return thisLogger.logrus.GetLevel().String()
+return thisLogger.logrus.GetLevel().String()
 }
 
 func getFormatter(loggerName string) *cblogformatter.Formatter {
 
-	if thisFormatter != nil {
-		return thisFormatter
-	}
-	thisFormatter = &cblogformatter.Formatter{
-		TimestampFormat: "2006-01-02 15:04:05",
-		LogFormat:       "[" + loggerName + "]." + "[%lvl%]: %time% %func% - %msg% \t[%keyvalues%]\n",
-	}
-	return thisFormatter
+if thisFormatter != nil {
+return thisFormatter
+}
+thisFormatter = &cblogformatter.Formatter{
+TimestampFormat: "2006-01-02 15:04:05",
+LogFormat:       "[" + loggerName + "]." + "[%lvl%]: %time% %func% - %msg% \t[%keyvalues%]\n",
+}
+return thisFormatter
 }

--- a/cblogger_test.go
+++ b/cblogger_test.go
@@ -177,3 +177,89 @@ logfileinfo:
 		t.Errorf("after file update: expected level 'error', got '%s'", got)
 	}
 }
+
+// TestDynamicLevelChange_AtomicSave verifies that the watcher survives an
+// atomic save (remove old file + create new file), which is the default
+// behaviour of many editors (vim, emacs) and tools (sed -i).
+func TestDynamicLevelChange_AtomicSave(t *testing.T) {
+resetGlobals()
+defer resetGlobals()
+
+const initialYAML = `
+cblog:
+  loglevel: info
+  console: false
+  logfile: false
+logfileinfo:
+  filename: ./log/test.log
+  maxsize: 5
+  maxbackups: 2
+  maxage: 7
+`
+dir, cfgPath := writeConfig(t, initialYAML)
+t.Setenv("CBLOG_ROOT", dir)
+
+logger := GetLogger("TEST-ATOMIC")
+if logger == nil {
+t.Fatal("expected non-nil logger")
+}
+if got := GetLevel(); got != "info" {
+t.Fatalf("initial level: expected 'info', got '%s'", got)
+}
+
+// Give the watcher goroutine time to start.
+time.Sleep(300 * time.Millisecond)
+
+// Simulate atomic save: remove old file, then write new file.
+if err := os.Remove(cfgPath); err != nil {
+t.Fatalf("Remove: %v", err)
+}
+
+// Brief pause to simulate the gap between remove and recreate.
+time.Sleep(50 * time.Millisecond)
+
+const updatedYAML = `
+cblog:
+  loglevel: debug
+  console: false
+  logfile: false
+logfileinfo:
+  filename: ./log/test.log
+  maxsize: 5
+  maxbackups: 2
+  maxage: 7
+`
+if err := os.WriteFile(cfgPath, []byte(updatedYAML), 0644); err != nil {
+t.Fatalf("WriteFile: %v", err)
+}
+
+// Allow up to 3 s for the watcher to pick up the change.
+deadline := time.Now().Add(3 * time.Second)
+for time.Now().Before(deadline) {
+if GetLevel() == "debug" {
+break
+}
+time.Sleep(100 * time.Millisecond)
+}
+
+if got := GetLevel(); got != "debug" {
+t.Errorf("after atomic save: expected level 'debug', got '%s'", got)
+}
+}
+
+// TestGetConfigInfosSafe_MissingFile verifies that GetConfigInfosSafe returns
+// an error (instead of calling log.Fatalf) when the config file does not exist.
+func TestGetConfigInfosSafe_MissingFile(t *testing.T) {
+dir := t.TempDir()
+t.Setenv("CBLOG_ROOT", dir)
+// conf/ directory exists but the file does not.
+confDir := filepath.Join(dir, "conf")
+if err := os.MkdirAll(confDir, 0755); err != nil {
+t.Fatalf("MkdirAll: %v", err)
+}
+
+_, err := GetConfigInfosSafe("")
+if err == nil {
+t.Fatal("expected error for missing config file, got nil")
+}
+}

--- a/config.go
+++ b/config.go
@@ -5,123 +5,158 @@
 // load and set config file
 //
 // ref) https://github.com/go-yaml/yaml/tree/v3
-//	https://godoc.org/gopkg.in/yaml.v3
+//https://godoc.org/gopkg.in/yaml.v3
 //
 // by CB-Log Team, 2019.08.
 
 package cblog
 
 import (
-	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
-	"strings"
+"fmt"
+"io/ioutil"
+"log"
+"os"
+"path/filepath"
+"strings"
 
-	"gopkg.in/yaml.v3"
+"gopkg.in/yaml.v3"
 )
 
 type CBLOGCONFIG struct {
-	CBLOG struct {
-		LOGLEVEL string
-		CONSOLE  bool
-		LOGFILE  bool
-	}
+CBLOG struct {
+LOGLEVEL string
+CONSOLE  bool
+LOGFILE  bool
+}
 
-	LOGFILEINFO struct {
-		FILENAME   string
-		MAXSIZE    int
-		MAXBACKUPS int
-		MAXAGE     int
-	}
+LOGFILEINFO struct {
+FILENAME   string
+MAXSIZE    int
+MAXBACKUPS int
+MAXAGE     int
+}
 }
 
 func NewCBLOGCONFIG() CBLOGCONFIG {
-	config := CBLOGCONFIG{}
+config := CBLOGCONFIG{}
 
-	config.CBLOG.LOGLEVEL = "info"
-	config.CBLOG.CONSOLE = true
-	config.CBLOG.LOGFILE = true
+config.CBLOG.LOGLEVEL = "info"
+config.CBLOG.CONSOLE = true
+config.CBLOG.LOGFILE = true
 
-	config.LOGFILEINFO.FILENAME = "./log/cblogs.log"
-	config.LOGFILEINFO.MAXSIZE = 10 // in MB
-	config.LOGFILEINFO.MAXBACKUPS = 5
-	config.LOGFILEINFO.MAXAGE = 31 // in days
+config.LOGFILEINFO.FILENAME = "./log/cblogs.log"
+config.LOGFILEINFO.MAXSIZE = 10 // in MB
+config.LOGFILEINFO.MAXBACKUPS = 5
+config.LOGFILEINFO.MAXAGE = 31 // in days
 
-	return config
+return config
 }
 
 func load(filePath string) ([]byte, error) {
-	data, err := ioutil.ReadFile(filePath)
-	return data, err
+data, err := ioutil.ReadFile(filePath)
+return data, err
 }
 
+// GetConfigInfos reads the configuration from the given path (or $CBLOG_ROOT/conf/log_conf.yaml).
+// It calls log.Fatalf on error and is intended for initial startup only.
 func GetConfigInfos(configFilePath string) CBLOGCONFIG {
-	var filePath string
+var filePath string
 
-	cblogRootPath := os.Getenv("CBLOG_ROOT")
-	if cblogRootPath == "" {
-		log.Printf("CBLOG_ROOT is not set. Using default configurations")
-		return NewCBLOGCONFIG()
-	}
+cblogRootPath := os.Getenv("CBLOG_ROOT")
+if cblogRootPath == "" {
+log.Printf("CBLOG_ROOT is not set. Using default configurations")
+return NewCBLOGCONFIG()
+}
 
-	if cblogRootPath == "" && configFilePath == "" {
-		log.Fatalf("Both $CBLOG_ROOT and configPath are not set!!")
-	}
+if cblogRootPath == "" && configFilePath == "" {
+log.Fatalf("Both $CBLOG_ROOT and configPath are not set!!")
+}
 
-	if cblogRootPath != "" {
-		filePath = filepath.Join(cblogRootPath, "conf", "log_conf.yaml")
-	} else {
-		filePath = configFilePath
-	}
+if cblogRootPath != "" {
+filePath = filepath.Join(cblogRootPath, "conf", "log_conf.yaml")
+} else {
+filePath = configFilePath
+}
 
-	data, err := load(filePath)
+data, err := load(filePath)
 
-	if err != nil {
-		log.Fatalf("error: %v", err)
-	}
+if err != nil {
+log.Fatalf("error: %v", err)
+}
 
-	configInfos := NewCBLOGCONFIG()
-	err = yaml.Unmarshal([]byte(data), &configInfos)
-	if err != nil {
-		log.Fatalf("error: %v", err)
-	}
-	configInfos.LOGFILEINFO.FILENAME = ReplaceEnvPath(configInfos.LOGFILEINFO.FILENAME)
-	return configInfos
+configInfos := NewCBLOGCONFIG()
+err = yaml.Unmarshal([]byte(data), &configInfos)
+if err != nil {
+log.Fatalf("error: %v", err)
+}
+configInfos.LOGFILEINFO.FILENAME = ReplaceEnvPath(configInfos.LOGFILEINFO.FILENAME)
+return configInfos
+}
+
+// GetConfigInfosSafe is like GetConfigInfos but returns an error instead of
+// calling log.Fatalf. This is used for runtime config reloads where a
+// transient failure (e.g. file not yet available during atomic save) should
+// not terminate the process.
+func GetConfigInfosSafe(configFilePath string) (CBLOGCONFIG, error) {
+var filePath string
+
+cblogRootPath := os.Getenv("CBLOG_ROOT")
+if cblogRootPath == "" && configFilePath == "" {
+return NewCBLOGCONFIG(), fmt.Errorf("both $CBLOG_ROOT and configPath are not set")
+}
+
+if cblogRootPath != "" {
+filePath = filepath.Join(cblogRootPath, "conf", "log_conf.yaml")
+} else {
+filePath = configFilePath
+}
+
+data, err := load(filePath)
+if err != nil {
+return cblogConfig, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+}
+
+configInfos := NewCBLOGCONFIG()
+err = yaml.Unmarshal([]byte(data), &configInfos)
+if err != nil {
+return cblogConfig, fmt.Errorf("failed to parse config file %s: %w", filePath, err)
+}
+configInfos.LOGFILEINFO.FILENAME = ReplaceEnvPath(configInfos.LOGFILEINFO.FILENAME)
+return configInfos, nil
 }
 
 // $ABC/def ==> /abc/def
 func ReplaceEnvPath(str string) string {
-	if strings.Index(str, "$") == -1 {
-		return str
-	}
+if strings.Index(str, "$") == -1 {
+return str
+}
 
-	// ex) input "$CBSTORE_ROOT/meta_db/dat"
-	strList := strings.Split(str, "/")
-	for n, one := range strList {
-		if strings.Index(one, "$") != -1 {
-			cbstoreRootPath := os.Getenv(strings.Trim(one, "$"))
-			if cbstoreRootPath == "" {
-				log.Fatal(one + " is not set!")
-			}
-			strList[n] = cbstoreRootPath
-		}
-	}
+// ex) input "$CBSTORE_ROOT/meta_db/dat"
+strList := strings.Split(str, "/")
+for n, one := range strList {
+if strings.Index(one, "$") != -1 {
+cbstoreRootPath := os.Getenv(strings.Trim(one, "$"))
+if cbstoreRootPath == "" {
+log.Fatal(one + " is not set!")
+}
+strList[n] = cbstoreRootPath
+}
+}
 
-	var resultStr string
-	for _, one := range strList {
-		resultStr = resultStr + one + "/"
-	}
-	// ex) "/root/go/src/github.com/cloud-barista/cb-spider/meta_db/dat/"
-	resultStr = strings.TrimRight(resultStr, "/")
-	resultStr = strings.ReplaceAll(resultStr, "//", "/")
-	return resultStr
+var resultStr string
+for _, one := range strList {
+resultStr = resultStr + one + "/"
+}
+// ex) "/root/go/src/github.com/cloud-barista/cb-spider/meta_db/dat/"
+resultStr = strings.TrimRight(resultStr, "/")
+resultStr = strings.ReplaceAll(resultStr, "//", "/")
+return resultStr
 }
 
 func GetConfigString(configInfos *CBLOGCONFIG) string {
-	d, err := yaml.Marshal(configInfos)
-	if err != nil {
-		log.Fatalf("error: %v", err)
-	}
-	return string(d)
+d, err := yaml.Marshal(configInfos)
+if err != nil {
+log.Fatalf("error: %v", err)
+}
+return string(d)
 }


### PR DESCRIPTION
The fsnotify-based config file watcher introduced in v0.11.0 fails when editors perform atomic saves (remove + create). Two issues are fixed:

1. Watch the parent *directory* instead of the file itself. This ensures the watcher survives file removal and receives the subsequent Create event when the new file appears.

2. Add GetConfigInfosSafe() that returns an error instead of calling log.Fatalf(). reloadConfig() now uses this safe variant so that a transient file-system condition during an atomic save does not terminate the process.

A 200ms debounce timer is added to coalesce rapid events from multi-step save operations.

Added tests: TestDynamicLevelChange_AtomicSave and TestGetConfigInfosSafe_MissingFile.